### PR TITLE
fix: respect user's FZF_DEFAULT_OPTS in fzf execution

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,12 +93,15 @@ func runInteractive(extraSSHArgs []string) error {
 		return fmt.Errorf("fzf not found in PATH. Please install fzf: https://github.com/junegunn/fzf")
 	}
 
-	fzf := exec.Command("fzf",
-		"--prompt", "sls> ",
-		"--height", "~50%",
-		"--layout", "reverse",
-		"--preview", "sls preview {}",
-	)
+	fzfArgs := []string{"--prompt", "sls > ", "--preview", "sls preview {}"}
+	if os.Getenv("FZF_DEFAULT_OPTS") == "" {
+		fzfArgs = append(fzfArgs,
+			"--height", "~50%",
+			"--layout", "reverse",
+		)
+	}
+
+	fzf := exec.Command("fzf", fzfArgs...)
 	fzf.Stdin = strings.NewReader(strings.Join(aliases, "\n"))
 
 	var out bytes.Buffer

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,7 +94,7 @@ func runInteractive(extraSSHArgs []string) error {
 	}
 
 	fzfArgs := []string{"--prompt", "sls > ", "--preview", "sls preview {}"}
-	if os.Getenv("FZF_DEFAULT_OPTS") == "" {
+	if !hasUserFzfConfig() {
 		fzfArgs = append(fzfArgs,
 			"--height", "~50%",
 			"--layout", "reverse",
@@ -127,6 +127,18 @@ func runInteractive(extraSSHArgs []string) error {
 	}
 
 	return runner.SSH(choice, extraSSHArgs)
+}
+
+func hasUserFzfConfig() bool {
+	if os.Getenv("FZF_DEFAULT_OPTS") != "" {
+		return true
+	}
+	if optsFile := os.Getenv("FZF_DEFAULT_OPTS_FILE"); optsFile != "" {
+		if _, err := os.Stat(optsFile); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func Execute() {


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes a **display clipping issue** observed in **WSL (Windows Subsystem for Linux)** and some terminal environments by respecting the user's `FZF_DEFAULT_OPTS` environment variable.

Previously, `sls` forced hardcoded layout flags (`--height ~50%`, `--layout reverse`, `--prompt sls>`), which often conflicted with user-defined fzf configurations and caused visual artifacts.

<img width="962" height="131" alt="img1" src="https://github.com/user-attachments/assets/87dfb94b-d754-4dd8-8c23-5d47711f527d" />

> [!Note]
> This issue was **reproducible in WSL environments**, but **could not be reproduced on macOS** terminals.

With this change: 
- `sls` will only apply its internal default flags if `FZF_DEFAULT_OPTS` is not set. 
- User-defined fzf settings are respected
- The `--prompt` and `--preview` flag remains managed by sls to ensure functionality. 
- Users can now customize the sls UI (borders, height, colors, etc.) through their global fzf settings.

<img width="711" height="131" alt="image" src="https://github.com/user-attachments/assets/d7737411-ef74-4bef-8067-2fce22f96ee9" />

## Type of Change

Select all that apply:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring or cleanup

## Checklist

- [x] Code builds successfully
- [ ] Tests pass or have been updated
- [ ] Documentation is updated where applicable

## Related Issues

Closes #
