### PR TITLE
feat: add `sls config format` command

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -124,7 +124,15 @@ func init() {
 		},
 	}
 
-	configCmd.AddCommand(cfgListCmd, cfgAddCmd, cfgEditCmd, cfgRemoveCmd)
+	cfgFormatCmd := &cobra.Command{
+		Use:   "format",
+		Short: "Format ~/.ssh/config with consistent style",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return config.FormatConfig("")
+		},
+	}
+
+	configCmd.AddCommand(cfgListCmd, cfgAddCmd, cfgEditCmd, cfgRemoveCmd, cfgFormatCmd)
 }
 
 // RunConfigAdd is an exported function to add a host programmatically.

--- a/internal/config/editor.go
+++ b/internal/config/editor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/jinmugo/sls/internal/consts"
 	sshconfig "github.com/kevinburke/ssh_config"
@@ -55,6 +56,105 @@ func SaveAST(cfg *sshconfig.Config, path string) error {
 	}
 	// SSH config files should be 0600 for security
 	return os.WriteFile(path, buf.Bytes(), 0o600)
+}
+
+// FormatConfig reads the SSH config file, formats it with consistent style, and writes it back.
+// It preserves all hosts (including *), comments, and Include directives.
+// A backup is created at <path>.bak before writing.
+func FormatConfig(custom string) error {
+	path := custom
+	if path == "" {
+		home, _ := os.UserHomeDir()
+		path = filepath.Join(home, ".ssh", "config")
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	cfg, err := sshconfig.Decode(f)
+	if err != nil {
+		return fmt.Errorf("failed to parse SSH config: %w", err)
+	}
+
+	// Create backup
+	original, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read original file: %w", err)
+	}
+	bakPath := path + ".bak"
+	if err := os.WriteFile(bakPath, original, 0o600); err != nil {
+		return fmt.Errorf("failed to create backup at %s: %w", bakPath, err)
+	}
+
+	var buf bytes.Buffer
+	for i, h := range cfg.Hosts {
+		isImplicit := (i == 0 && len(h.Patterns) > 0 && h.Patterns[0].String() == "*")
+
+		if !isImplicit {
+			// Write Host line
+			patterns := make([]string, len(h.Patterns))
+			for j, p := range h.Patterns {
+				patterns[j] = p.String()
+			}
+			buf.WriteString(fmt.Sprintf("Host %s", strings.Join(patterns, " ")))
+			if h.EOLComment != "" {
+				buf.WriteString(" #" + h.EOLComment)
+			}
+			buf.WriteByte('\n')
+		}
+
+		// Write nodes, trimming trailing empty lines
+		nodes := h.Nodes
+		for len(nodes) > 0 {
+			if e, ok := nodes[len(nodes)-1].(*sshconfig.Empty); ok && e.Comment == "" {
+				nodes = nodes[:len(nodes)-1]
+			} else {
+				break
+			}
+		}
+		for _, n := range nodes {
+			switch node := n.(type) {
+			case *sshconfig.KV:
+				indent := "    "
+				if isImplicit {
+					indent = ""
+				}
+				line := fmt.Sprintf("%s%s %s", indent, node.Key, node.Value)
+				if node.Comment != "" {
+					line += " #" + node.Comment
+				}
+				buf.WriteString(line)
+				buf.WriteByte('\n')
+			case *sshconfig.Empty:
+				if node.Comment != "" {
+					indent := "    "
+					if isImplicit {
+						indent = ""
+					}
+					buf.WriteString(fmt.Sprintf("%s#%s", indent, node.Comment))
+				}
+				buf.WriteByte('\n')
+			case *sshconfig.Include:
+				buf.WriteString(node.String())
+				buf.WriteByte('\n')
+			}
+		}
+
+		// Blank line between host blocks
+		if i < len(cfg.Hosts)-1 {
+			buf.WriteByte('\n')
+		}
+	}
+
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("failed to write formatted config: %w", err)
+	}
+
+	fmt.Printf("✓ Formatted %s (backup: %s)\n", path, bakPath)
+	return nil
 }
 
 func FindHost(cfg *sshconfig.Config, alias string) (*sshconfig.Host, int) {


### PR DESCRIPTION
## Summary
- Add `sls config format` command to auto-format `~/.ssh/config` with consistent style
- Normalize indentation to 4 spaces and key-value separator to single space
- Preserve comments, Include directives, and `Host *` blocks
- Auto-create `.bak` backup before writing
- Idempotent — safe to run multiple times with identical output

## Test plan
- [ ] Build with `go build -o sls .`
- [ ] Run `sls config format` and verify formatted output
- [ ] Verify `.bak` backup file is created
- [ ] Run twice consecutively and confirm no diff (idempotency)
- [ ] Confirm comments, Include directives, and `Host *` are preserved