### PR TITLE
chore: update GitHub Actions to support Node.js 24

### DIFF
--- a/.github/workflows/publish-packages.yaml
+++ b/.github/workflows/publish-packages.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout package repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: jinmugo/package.jinmu.me
           token: ${{ secrets.PACKAGE_REPO_TOKEN }}
@@ -175,6 +175,8 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,17 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
       # More assembly might be required: Docker logins, GPG, etc.
       # It all depends on your needs.
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v4 to v6
- Upgrade `actions/setup-go` from v5 to v6
- Upgrade `goreleaser/goreleaser-action` from v6 to v7
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env for `cloudflare/wrangler-action@v3` (no v4 available yet)

## Why
Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2, 2026.

## Test plan
- [ ] Run `publish-packages` workflow via `workflow_dispatch` and verify no Node.js deprecation warnings
- [ ] Verify `release` workflow passes on PR check (snapshot build)