### PR TITLE
feat: inject telemetry endpoint and API key at build time via ldflags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,3 +31,5 @@ jobs:
           args: ${{ github.event_name == 'pull_request' && 'release --snapshot --skip=publish --clean' || 'release --clean' }}
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          TELEMETRY_ENDPOINT: ${{ secrets.TELEMETRY_ENDPOINT }}
+          TELEMETRY_API_KEY: ${{ secrets.TELEMETRY_API_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,8 @@ builds:
       - -X github.com/jinmugo/sls/cmd.commit={{.Commit}}
       - -X github.com/jinmugo/sls/cmd.date={{.Date}}
       - -X github.com/jinmugo/sls/cmd.builtBy=goreleaser
+      - -X github.com/jinmugo/sls/internal/pulse.defaultEndpoint={{.Env.TELEMETRY_ENDPOINT}}
+      - -X github.com/jinmugo/sls/internal/pulse.defaultAPIKey={{.Env.TELEMETRY_API_KEY}}
 
 archives:
   - formats: [tar.gz]

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,16 @@ COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILT_BY ?= $(shell whoami)
 
+TELEMETRY_ENDPOINT ?= https://telemetry.jinmu.me
+TELEMETRY_API_KEY ?= pulse-dev-key
+
 LDFLAGS := -s -w \
 	-X github.com/jinmugo/sls/cmd.version=$(VERSION) \
 	-X github.com/jinmugo/sls/cmd.commit=$(COMMIT) \
 	-X github.com/jinmugo/sls/cmd.date=$(DATE) \
-	-X github.com/jinmugo/sls/cmd.builtBy=$(BUILT_BY)
+	-X github.com/jinmugo/sls/cmd.builtBy=$(BUILT_BY) \
+	-X github.com/jinmugo/sls/internal/pulse.defaultEndpoint=$(TELEMETRY_ENDPOINT) \
+	-X github.com/jinmugo/sls/internal/pulse.defaultAPIKey=$(TELEMETRY_API_KEY)
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'

--- a/internal/pulse/pulse.go
+++ b/internal/pulse/pulse.go
@@ -28,9 +28,13 @@ import (
 	"time"
 )
 
+// Overridable at build time via -ldflags "-X github.com/jinmugo/sls/internal/pulse.defaultEndpoint=... -X ...defaultAPIKey=..."
+var (
+	defaultEndpoint = "https://telemetry.jinmu.me"
+	defaultAPIKey   = "pulse-dev-key"
+)
+
 const (
-	defaultEndpoint  = "https://pulse.jinmu.me"
-	defaultAPIKey    = "pulse-dev-key"
 	flushInterval    = 30 * time.Second
 	maxQueueSize     = 50
 	batchThreshold   = 10
@@ -70,8 +74,8 @@ func Init(version string) {
 		return
 	}
 
-	endpoint = getEnv("PULSE_ENDPOINT", defaultEndpoint)
-	apiKey = getEnv("PULSE_API_KEY", defaultAPIKey)
+	endpoint = getEnv("TELEMETRY_ENDPOINT", defaultEndpoint)
+	apiKey = getEnv("TELEMETRY_API_KEY", defaultAPIKey)
 
 	ctx = map[string]interface{}{
 		"os":      runtime.GOOS,


### PR DESCRIPTION
  ## Summary

  - Change `defaultEndpoint` / `defaultAPIKey` from `const` to `var` to allow ldflags override at build time
  - Add `TELEMETRY_ENDPOINT` and `TELEMETRY_API_KEY` variables to Makefile
  - Inject both values via ldflags in `.goreleaser.yaml`
  - Pass secrets from GitHub Actions release workflow (`TELEMETRY_ENDPOINT`, `TELEMETRY_API_KEY`)
  - Rename runtime override env vars from `PULSE_*` to `TELEMETRY_*` for consistency

  ## Setup Required

  Add the following two secrets in GitHub repository Settings → Secrets:
  - `TELEMETRY_ENDPOINT`
  - `TELEMETRY_API_KEY`