### PR TITLE
ci: sign individual RPMs before publishing

### DIFF
--- a/.github/workflows/publish-packages.yaml
+++ b/.github/workflows/publish-packages.yaml
@@ -59,7 +59,25 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y dpkg-dev createrepo-c
+          sudo apt-get install -y dpkg-dev createrepo-c rpm
+
+      - name: Sign RPM packages
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+        run: |
+          cat > ~/.rpmmacros << 'EOF'
+          %_signature gpg
+          %_gpg_name GPG_KEY_ID_PLACEHOLDER
+          %__gpg /usr/bin/gpg
+          %__gpg_sign_cmd %{__gpg} gpg --batch --no-armor --pinentry-mode loopback --passphrase GPG_PASSPHRASE_PLACEHOLDER --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}
+          EOF
+          sed -i "s|GPG_KEY_ID_PLACEHOLDER|$GPG_KEY_ID|g" ~/.rpmmacros
+          sed -i "s|GPG_PASSPHRASE_PLACEHOLDER|$GPG_PASSPHRASE|g" ~/.rpmmacros
+
+          for rpm in artifacts/*.rpm; do
+            rpmsign --addsign "$rpm"
+          done
 
       - name: Setup APT repository
         env:


### PR DESCRIPTION
## Summary

Port of `jinmugo/cinch#7`. dnf rejects unsigned packages when `gpgcheck=1`, so `dnf install sls` fails on Fedora even though the repo metadata is signed. Add an `rpmsign --addsign` step that signs every `.rpm` with the repo GPG key before `createrepo_c` indexes them, using `pinentry-mode loopback` + `GPG_PASSPHRASE` secret for fully non-interactive signing.

## Test plan

- [ ] After merge, re-run publish-packages for current sls tag (`v1.2.0`) via `workflow_dispatch` to re-sign existing RPMs
- [ ] `curl -fsSL https://package.jinmu.me/install.sh | sudo sh -s sls` succeeds on Fedora