### PR TITLE
fix: set relative base path in vite config

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: './'
+});


### PR DESCRIPTION
Sets the Vite asset base path to relative (`./`) so that static resources (JS, CSS, favicon, etc.) resolve correctly when hosting in subfolders (like `jinmugo.github.io/sls/`) as well as on custom domains. Resolves the 404 resource errors.