### PR TITLE
feat: ship telemetry as OTLP to the observability stack (sls in Grafana)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,7 @@ builds:
       - -X github.com/jinmugo/sls/cmd.date={{.Date}}
       - -X github.com/jinmugo/sls/cmd.builtBy=goreleaser
       - -X github.com/jinmugo/sls/internal/pulse.defaultEndpoint={{.Env.TELEMETRY_ENDPOINT}}
-      - -X github.com/jinmugo/sls/internal/pulse.defaultAPIKey={{.Env.TELEMETRY_API_KEY}}
+      - -X github.com/jinmugo/sls/internal/pulse.defaultIngestToken={{.Env.TELEMETRY_API_KEY}}
 
 archives:
   - formats: [tar.gz]

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,10 @@ COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILT_BY ?= $(shell whoami)
 
-TELEMETRY_ENDPOINT ?= https://telemetry.jinmu.me
-TELEMETRY_API_KEY ?= pulse-dev-key
+# OTLP ingest front door + the CLI's Bearer token. TELEMETRY_API_KEY now carries
+# the ingest Bearer token (a separately-revocable CLI token, not the relay token).
+TELEMETRY_ENDPOINT ?= https://ingest.jinmu.me
+TELEMETRY_API_KEY ?= ingest-dev-token
 
 LDFLAGS := -s -w \
 	-X github.com/jinmugo/sls/cmd.version=$(VERSION) \
@@ -14,7 +16,7 @@ LDFLAGS := -s -w \
 	-X github.com/jinmugo/sls/cmd.date=$(DATE) \
 	-X github.com/jinmugo/sls/cmd.builtBy=$(BUILT_BY) \
 	-X github.com/jinmugo/sls/internal/pulse.defaultEndpoint=$(TELEMETRY_ENDPOINT) \
-	-X github.com/jinmugo/sls/internal/pulse.defaultAPIKey=$(TELEMETRY_API_KEY)
+	-X github.com/jinmugo/sls/internal/pulse.defaultIngestToken=$(TELEMETRY_API_KEY)
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ sls completion [bash|zsh|fish|powershell]
 | `~/.config/sls/meta.json` | Favorites, usage counts, tags |
 | `~/.config/sls/containers.json` | Cached container data |
 | `~/.config/sls/ssh_config` | Generated container SSH entries |
+| `~/.config/sls/telemetry` | Telemetry consent (`enabled`/`disabled`) |
+| `~/.config/sls/anon_id` | Random per-install anonymous id (see Telemetry) |
 
 ## Security
 
@@ -199,3 +201,20 @@ sls completion [bash|zsh|fish|powershell]
 - All file writes use atomic temp-file-then-rename to prevent corruption
 - The generated SSH config is a separate include file, never modifying your hand-crafted SSH config
 - SSH connections use `BatchMode=yes` to prevent hanging on auth prompts during discovery
+
+## Telemetry
+
+sls collects **anonymous, opt-in** usage data to guide what to improve. On first
+interactive run it asks for consent (stored in `~/.config/sls/telemetry`); it never
+prompts in non-interactive/CI/piped contexts and stays off until you opt in.
+
+- **Collected:** command name (e.g. `connect`, `scan`), OS, architecture, sls
+  version, and a random per-install `anon_id` (a v4 UUID in `~/.config/sls/anon_id`,
+  generated from randomness alone — not derived from any hostname, user, or machine).
+- **Never collected:** hostnames, IP addresses, SSH config, container names, paths,
+  or any personal data.
+- **Opt out anytime:** `export PULSE_DISABLED=1` (or `SLS_TELEMETRY=off`), or set
+  `disabled` in `~/.config/sls/telemetry`.
+
+Events are sent fire-and-forget (short timeout, failures ignored) as OTLP/HTTP logs
+to a self-hosted collector and never block or slow down the CLI.

--- a/internal/pulse/pulse.go
+++ b/internal/pulse/pulse.go
@@ -1,5 +1,7 @@
-// Package pulse provides a lightweight, non-blocking telemetry client
-// for the Pulse event collection server (pulse.jinmu.me).
+// Package pulse provides a lightweight, non-blocking telemetry client that ships
+// anonymous usage events to the self-hosted observability stack's OTLP ingest
+// front door (ingest.jinmu.me). Events land in VictoriaLogs and surface in the
+// portfolio Grafana under the service label "sls".
 //
 // Usage:
 //
@@ -7,64 +9,123 @@
 //	pulse.Track("command_run", pulse.Props{"command": "connect"})
 //	defer pulse.Shutdown()        // flush remaining events on exit
 //
-// Telemetry is opt-in: on first run, the user is prompted to consent.
-// Consent is stored in ~/.config/sls/telemetry.
-// Can also be controlled via PULSE_DISABLED=1 or SLS_TELEMETRY=off.
-// Events are queued in memory and flushed asynchronously.
-// Network failures are silently ignored.
+// Wire format is OTLP/HTTP logs (POST /v1/logs, Authorization: Bearer <token>).
+// Each event becomes one OTLP log record: resource attribute service.name="sls",
+// the record body is the event name, and the flat record attributes (event,
+// anon_id, os, arch, version, runtime, plus any Props) are what the Grafana
+// panels key on — count_uniq(anon_id) for active users, stats by(event) for top
+// events. The collector copies service.name -> the "service" field used by the
+// dashboard's $service variable.
+//
+// Telemetry is opt-in: on first run, the user is prompted to consent. Consent is
+// stored in ~/.config/sls/telemetry. Can also be controlled via PULSE_DISABLED=1
+// or SLS_TELEMETRY=off. Events are queued in memory and flushed asynchronously;
+// network failures are silently ignored. The only identifiers that ever leave the
+// process are the event/command names, OS/arch/version, and a random per-install
+// anon_id (a v4 UUID in ~/.config/sls/anon_id, derived from nothing — never a
+// hostname, IP, path, or SSH config).
 package pulse
 
 import (
 	"bufio"
 	"bytes"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
 
-// Overridable at build time via -ldflags "-X github.com/jinmugo/sls/internal/pulse.defaultEndpoint=... -X ...defaultAPIKey=..."
+// Overridable at build time via -ldflags "-X github.com/jinmugo/sls/internal/pulse.defaultEndpoint=... -X ...defaultIngestToken=...".
+// defaultIngestToken is the Bearer token the public CLI presents to the ingest
+// front door; it is a separately-revocable token (NOT the relay's server token).
 var (
-	defaultEndpoint = "https://telemetry.jinmu.me"
-	defaultAPIKey   = "pulse-dev-key"
+	defaultEndpoint    = "https://ingest.jinmu.me"
+	defaultIngestToken = "ingest-dev-token"
 )
 
 const (
-	flushInterval    = 30 * time.Second
-	maxQueueSize     = 50
-	batchThreshold   = 10
-	httpTimeout      = 2 * time.Second
-	consentFile      = "telemetry" // stored in ~/.config/sls/
+	flushInterval  = 30 * time.Second
+	maxQueueSize   = 50
+	batchThreshold = 10
+	httpTimeout    = 2 * time.Second
+	consentFile    = "telemetry" // stored in ~/.config/sls/
+	anonIDFile     = "anon_id"   // stored in ~/.config/sls/
+	serviceName    = "sls"       // OTLP resource attribute service.name
 )
 
-// Props is a shorthand for event properties.
-type Props map[string]interface{}
+// Props is a shorthand for event properties. Values are strings because OTLP log
+// attributes are emitted as stringValue and the project bans the any type.
+type Props map[string]string
 
+// event is the in-memory representation queued between flushes. attrs is the
+// pre-built flat OTLP attribute list (event, anon_id, context, and Props); nano
+// is the capture time in Unix nanoseconds.
 type event struct {
-	App        string                 `json:"app"`
-	Event      string                 `json:"event"`
-	Context    map[string]interface{} `json:"context,omitempty"`
-	Properties map[string]interface{} `json:"properties,omitempty"`
-	Timestamp  string                 `json:"timestamp"`
+	name  string
+	nano  int64
+	attrs []otlpKeyValue
 }
 
 var (
-	mu       sync.Mutex
-	queue    []event
-	ctx      map[string]interface{}
-	client   *http.Client
-	endpoint string
-	apiKey   string
-	disabled bool
-	started  bool
-	stopCh   chan struct{}
-	wg       sync.WaitGroup
+	mu        sync.Mutex
+	queue     []event
+	ctxAttrs  []otlpKeyValue // os/arch/version/runtime, built once in Init
+	anonID    string
+	client    *http.Client
+	endpoint  string
+	token     string
+	userAgent string
+	disabled  bool
+	started   bool
+	stopCh    chan struct{}
+	wg        sync.WaitGroup
 )
+
+// ---- OTLP/HTTP logs payload (typed; the project bans the any type) ----------
+
+type otlpStringValue struct {
+	StringValue string `json:"stringValue"`
+}
+
+type otlpKeyValue struct {
+	Key   string          `json:"key"`
+	Value otlpStringValue `json:"value"`
+}
+
+type otlpLogRecord struct {
+	TimeUnixNano string          `json:"timeUnixNano"`
+	Body         otlpStringValue `json:"body"`
+	Attributes   []otlpKeyValue  `json:"attributes"`
+}
+
+type otlpScopeLogs struct {
+	LogRecords []otlpLogRecord `json:"logRecords"`
+}
+
+type otlpResource struct {
+	Attributes []otlpKeyValue `json:"attributes"`
+}
+
+type otlpResourceLogs struct {
+	Resource  otlpResource    `json:"resource"`
+	ScopeLogs []otlpScopeLogs `json:"scopeLogs"`
+}
+
+type otlpLogsBody struct {
+	ResourceLogs []otlpResourceLogs `json:"resourceLogs"`
+}
+
+// kv builds a flat OTLP string attribute.
+func kv(key, val string) otlpKeyValue {
+	return otlpKeyValue{Key: key, Value: otlpStringValue{StringValue: val}}
+}
 
 // Init initializes the telemetry client with the given sls version.
 // Must be called once before Track(). Safe to call even if telemetry is disabled.
@@ -74,15 +135,17 @@ func Init(version string) {
 		return
 	}
 
-	endpoint = getEnv("TELEMETRY_ENDPOINT", defaultEndpoint)
-	apiKey = getEnv("TELEMETRY_API_KEY", defaultAPIKey)
+	endpoint = strings.TrimRight(getEnv("TELEMETRY_ENDPOINT", defaultEndpoint), "/")
+	token = getEnv("TELEMETRY_API_KEY", defaultIngestToken)
+	userAgent = "sls/" + version
 
-	ctx = map[string]interface{}{
-		"os":      runtime.GOOS,
-		"arch":    runtime.GOARCH,
-		"version": version,
-		"runtime": fmt.Sprintf("go%s", runtime.Version()[2:]), // strip "go" prefix from "go1.25.0"
+	ctxAttrs = []otlpKeyValue{
+		kv("os", runtime.GOOS),
+		kv("arch", runtime.GOARCH),
+		kv("version", version),
+		kv("runtime", fmt.Sprintf("go%s", runtime.Version()[2:])), // strip "go" prefix from "go1.25.0"
 	}
+	anonID = loadOrCreateAnonID()
 
 	client = &http.Client{Timeout: httpTimeout}
 	queue = make([]event, 0, maxQueueSize)
@@ -100,12 +163,19 @@ func Track(eventName string, properties Props) {
 		return
 	}
 
+	// Pre-build the flat OTLP attributes the Grafana panels key on exactly:
+	// "event" + "anon_id" are required (stats by(event), count_uniq(anon_id)).
+	attrs := make([]otlpKeyValue, 0, 2+len(ctxAttrs)+len(properties))
+	attrs = append(attrs, kv("event", eventName), kv("anon_id", anonID))
+	attrs = append(attrs, ctxAttrs...)
+	for k, v := range properties {
+		attrs = append(attrs, kv(k, v))
+	}
+
 	e := event{
-		App:        "sls",
-		Event:      eventName,
-		Context:    ctx,
-		Properties: properties,
-		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		name:  eventName,
+		nano:  time.Now().UnixNano(),
+		attrs: attrs,
 	}
 
 	mu.Lock()
@@ -149,6 +219,9 @@ func flushLoop() {
 	}
 }
 
+// flush drains the queue and POSTs it as a single OTLP/HTTP logs request: one
+// resourceLogs (service.name="sls") carrying every queued event as a log record.
+// All errors are swallowed — telemetry must never affect the main flow.
 func flush() {
 	mu.Lock()
 	if len(queue) == 0 {
@@ -160,20 +233,36 @@ func flush() {
 	queue = queue[:0]
 	mu.Unlock()
 
-	body := map[string]interface{}{
-		"events": batch,
+	records := make([]otlpLogRecord, len(batch))
+	for i, e := range batch {
+		records[i] = otlpLogRecord{
+			TimeUnixNano: strconv.FormatInt(e.nano, 10),
+			Body:         otlpStringValue{StringValue: e.name},
+			Attributes:   e.attrs,
+		}
 	}
-	data, err := json.Marshal(body)
+	payload := otlpLogsBody{
+		ResourceLogs: []otlpResourceLogs{{
+			Resource:  otlpResource{Attributes: []otlpKeyValue{kv("service.name", serviceName)}},
+			ScopeLogs: []otlpScopeLogs{{LogRecords: records}},
+		}},
+	}
+
+	data, err := json.Marshal(payload)
 	if err != nil {
 		return // silently drop
 	}
 
-	req, err := http.NewRequest("POST", endpoint+"/v1/events/batch", bytes.NewReader(data))
+	req, err := http.NewRequest("POST", endpoint+"/v1/logs", bytes.NewReader(data))
 	if err != nil {
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Authorization", "Bearer "+token)
+	// Identify as a named client. Go's default User-Agent (Go-http-client/1.1)
+	// trips Cloudflare's bot-mitigation challenge on the ingest edge (HTTP 403);
+	// a non-browser client UA passes it.
+	req.Header.Set("User-Agent", userAgent)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -213,8 +302,24 @@ func hasConsent() bool {
 		return strings.TrimSpace(string(data)) == "enabled"
 	}
 
-	// No consent file — prompt the user
+	// No consent file. Only prompt when running interactively — otherwise (piped
+	// stdin, CI, shell-completion generation, scripted `sls connect`) reading
+	// stdin would block or consume unrelated input, and we'd persist a decision
+	// the user never saw. Treat non-interactive as "no consent" without writing
+	// the file, so a later interactive run can still ask.
+	if !isInteractive() {
+		return false
+	}
 	return promptConsent(path)
+}
+
+// isInteractive reports whether stdin is connected to a terminal.
+func isInteractive() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
 }
 
 func promptConsent(path string) bool {
@@ -247,6 +352,47 @@ func promptConsent(path string) bool {
 	_ = os.WriteFile(path, []byte(value+"\n"), 0o644)
 
 	return consented
+}
+
+// loadOrCreateAnonID returns a stable, random per-install identifier used for
+// count_uniq(anon_id) active-user counts. It is read from ~/.config/sls/anon_id,
+// generating and persisting a fresh v4 UUID on first use. The id is derived from
+// crypto/rand alone — it encodes no hostname, user, or machine fingerprint, so it
+// cannot be reversed to its source. Returns "" if the home dir is unavailable.
+func loadOrCreateAnonID() string {
+	path := anonIDPath()
+	if path == "" {
+		return ""
+	}
+	if data, err := os.ReadFile(path); err == nil {
+		if s := strings.TrimSpace(string(data)); s != "" {
+			return s
+		}
+	}
+	id := newAnonID()
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	_ = os.WriteFile(path, []byte(id+"\n"), 0o600)
+	return id
+}
+
+func anonIDPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "sls", anonIDFile)
+}
+
+// newAnonID returns a random RFC 4122 v4 UUID string.
+func newAnonID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Fall back to a time-based, still non-PII token if the RNG is unavailable.
+		return "t-" + strconv.FormatInt(time.Now().UnixNano(), 16)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
 
 func getEnv(key, fallback string) string {

--- a/internal/pulse/pulse_test.go
+++ b/internal/pulse/pulse_test.go
@@ -1,0 +1,206 @@
+package pulse
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// captured holds what the mock ingest endpoint received.
+type captured struct {
+	method string
+	path   string
+	auth   string
+	ua     string
+	body   otlpLogsBody
+}
+
+// newMockIngest returns a test server that records the first request into ch.
+func newMockIngest(t *testing.T, ch chan<- captured) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var b otlpLogsBody
+		_ = json.Unmarshal(raw, &b)
+		ch <- captured{
+			method: r.Method,
+			path:   r.URL.Path,
+			auth:   r.Header.Get("Authorization"),
+			ua:     r.Header.Get("User-Agent"),
+			body:   b,
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+// enableConsentIn writes an "enabled" consent file under home so hasConsent()
+// returns true without an interactive prompt.
+func enableConsentIn(t *testing.T, home string) {
+	t.Helper()
+	dir := filepath.Join(home, ".config", "sls")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, consentFile), []byte("enabled\n"), 0o644); err != nil {
+		t.Fatalf("write consent: %v", err)
+	}
+}
+
+// attrValue returns the stringValue of the first attribute with the given key.
+func attrValue(attrs []otlpKeyValue, key string) (string, bool) {
+	for _, a := range attrs {
+		if a.Key == key {
+			return a.Value.StringValue, true
+		}
+	}
+	return "", false
+}
+
+// TestTrackEmitsOTLP is the core wire-format guarantee: a tracked event reaches
+// the ingest endpoint as one OTLP/HTTP log POST with the Bearer token, a named
+// User-Agent, service.name="sls", and the flat attributes the Grafana panels
+// require (event, anon_id, the command prop, and the os/arch/version context).
+func TestTrackEmitsOTLP(t *testing.T) {
+	home := t.TempDir()
+	enableConsentIn(t, home)
+
+	ch := make(chan captured, 1)
+	srv := newMockIngest(t, ch)
+	defer srv.Close()
+
+	// Runtime overrides consumed by Init via getEnv. HOME redirects the consent +
+	// anon_id files into the temp dir so the real ~/.config/sls is never touched.
+	t.Setenv("HOME", home)
+	t.Setenv("PULSE_DISABLED", "")
+	t.Setenv("SLS_TELEMETRY", "")
+	t.Setenv("TELEMETRY_ENDPOINT", srv.URL)
+	t.Setenv("TELEMETRY_API_KEY", "test-cli-token")
+
+	// Reset package state so the test is independent of init order.
+	disabled, started = false, false
+
+	Init("9.9.9")
+	if disabled || !started {
+		t.Fatalf("Init did not enable telemetry (disabled=%v started=%v)", disabled, started)
+	}
+	Track("command_run", Props{"command": "connect"})
+	Shutdown() // synchronous flush
+
+	var got captured
+	select {
+	case got = <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal("ingest endpoint received no request")
+	}
+
+	if got.method != http.MethodPost {
+		t.Errorf("method = %q, want POST", got.method)
+	}
+	if got.path != "/v1/logs" {
+		t.Errorf("path = %q, want /v1/logs", got.path)
+	}
+	if got.auth != "Bearer test-cli-token" {
+		t.Errorf("Authorization = %q, want Bearer test-cli-token", got.auth)
+	}
+	if got.ua != "sls/9.9.9" {
+		t.Errorf("User-Agent = %q, want sls/9.9.9", got.ua)
+	}
+
+	if len(got.body.ResourceLogs) != 1 {
+		t.Fatalf("resourceLogs len = %d, want 1", len(got.body.ResourceLogs))
+	}
+	rl := got.body.ResourceLogs[0]
+	if v, _ := attrValue(rl.Resource.Attributes, "service.name"); v != serviceName {
+		t.Errorf("resource service.name = %q, want %q", v, serviceName)
+	}
+	if len(rl.ScopeLogs) != 1 || len(rl.ScopeLogs[0].LogRecords) != 1 {
+		t.Fatalf("want exactly one log record, got scopeLogs=%d", len(rl.ScopeLogs))
+	}
+	rec := rl.ScopeLogs[0].LogRecords[0]
+	if rec.Body.StringValue != "command_run" {
+		t.Errorf("record body = %q, want command_run", rec.Body.StringValue)
+	}
+	if rec.TimeUnixNano == "" {
+		t.Error("record timeUnixNano is empty")
+	}
+	if v, _ := attrValue(rec.Attributes, "event"); v != "command_run" {
+		t.Errorf("attr event = %q, want command_run", v)
+	}
+	if v, ok := attrValue(rec.Attributes, "anon_id"); !ok || v == "" {
+		t.Errorf("attr anon_id missing/empty (ok=%v val=%q)", ok, v)
+	}
+	if v, _ := attrValue(rec.Attributes, "command"); v != "connect" {
+		t.Errorf("attr command = %q, want connect", v)
+	}
+	if v, _ := attrValue(rec.Attributes, "version"); v != "9.9.9" {
+		t.Errorf("attr version = %q, want 9.9.9", v)
+	}
+}
+
+// TestDisabledViaEnv verifies the opt-out env vars keep telemetry fully off even
+// when consent is on: no request must reach the endpoint.
+func TestDisabledViaEnv(t *testing.T) {
+	home := t.TempDir()
+	enableConsentIn(t, home)
+
+	ch := make(chan captured, 1)
+	srv := newMockIngest(t, ch)
+	defer srv.Close()
+
+	t.Setenv("HOME", home)
+	t.Setenv("TELEMETRY_ENDPOINT", srv.URL)
+	t.Setenv("TELEMETRY_API_KEY", "test-cli-token")
+	t.Setenv("PULSE_DISABLED", "1")
+
+	disabled, started = false, false
+
+	Init("9.9.9")
+	if !disabled {
+		t.Fatal("PULSE_DISABLED=1 should disable telemetry")
+	}
+	Track("command_run", Props{"command": "connect"})
+	Shutdown()
+
+	select {
+	case <-ch:
+		t.Fatal("disabled telemetry still sent a request")
+	case <-time.After(300 * time.Millisecond):
+		// expected: nothing sent
+	}
+}
+
+// TestAnonIDStable verifies the anon_id persists across Init calls (same install
+// -> same id) so count_uniq(anon_id) counts installs, not invocations.
+func TestAnonIDStable(t *testing.T) {
+	home := t.TempDir()
+
+	first := func() string {
+		ch := make(chan captured, 1)
+		srv := newMockIngest(t, ch)
+		defer srv.Close()
+		enableConsentIn(t, home)
+		t.Setenv("HOME", home)
+		t.Setenv("PULSE_DISABLED", "")
+		t.Setenv("SLS_TELEMETRY", "")
+		t.Setenv("TELEMETRY_ENDPOINT", srv.URL)
+		t.Setenv("TELEMETRY_API_KEY", "tok")
+		disabled, started = false, false
+		Init("1.0.0")
+		Track("command_run", Props{"command": "scan"})
+		Shutdown()
+		got := <-ch
+		v, _ := attrValue(got.body.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Attributes, "anon_id")
+		return v
+	}
+
+	a := first()
+	b := first()
+	if a == "" || a != b {
+		t.Errorf("anon_id not stable across runs: %q vs %q", a, b)
+	}
+}


### PR DESCRIPTION
Repoints `internal/pulse` from the standalone Pulse server (`telemetry.jinmu.me`)
to the portfolio observability stack's OTLP ingest front door (`ingest.jinmu.me`),
so **sls shows up in the shared Grafana under `$service=sls`** alongside cinch/relay.

## What changed
- `internal/pulse/pulse.go` — emit **OTLP/HTTP logs** (`POST /v1/logs`, `Authorization: Bearer`,
  resource `service.name=sls`); flat attrs `event`/`anon_id`/`os`/`arch`/`version`/`command`.
  Keeps the existing opt-in consent + opt-out (`PULSE_DISABLED`/`SLS_TELEMETRY=off`) + queue +
  async flush. Adds a **named `User-Agent: sls/<ver>`** (the Cloudflare edge 403s the default Go UA).
  `Props` is now `map[string]string` (OTLP attrs are strings; no `any`). Includes the
  non-interactive consent guard.
- **Per-install `anon_id`** (random v4 UUID in `~/.config/sls/anon_id`, derived from nothing) so
  the Grafana "Active users" panel's `count_uniq(anon_id)` counts installs.
- `Makefile` / `.goreleaser.yaml` — defaults point at the ingest front door; symbol
  `defaultAPIKey`→`defaultIngestToken`. **CI secret names unchanged** (`TELEMETRY_ENDPOINT`/
  `TELEMETRY_API_KEY`) — their values now point at `ingest.jinmu.me` + a separate CLI token.
- First tests for the `pulse` package (wire format, opt-out, anon_id stability).
- `README.md` — Telemetry section.

## Already done (infra side, verified in prod)
- observability stack deployed with a multi-token collector gate; `SERVICE_PASSWORD_INGESTCLI`
  generated. Prod check: CLI token → `HTTP 200`, no token → `HTTP 401`.
- sls repo secrets `TELEMETRY_ENDPOINT` + `TELEMETRY_API_KEY` set to the ingest URL + CLI token.

## Verification
- `go build`/`vet`/`gofmt`/`go test ./internal/pulse/...` green (3 new tests pass).
- Local e2e: an sls-shaped event lands in VictoriaLogs as `service:sls` (`count_uniq(anon_id)=1`).

## To release after merge
Tag `v1.3.0` (next after `v1.2.2`) → goreleaser builds with the baked endpoint+token.

> Privacy unchanged: opt-in, anonymous; never sends hostnames/IPs/SSH config/paths.