### PR TITLE
feat: add auto-update check and 'sls update' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ go install github.com/jinmugo/sls@latest
 
 Download platform-specific binaries from the [Releases](https://github.com/jinmugo/sls/releases) page.
 
+## Updating
+
+sls checks for a newer release in the background (at most once a day) and shows a
+small `⬆ sls vX.Y.Z available` line in the dashboard when one exists. To upgrade:
+
+```bash
+sls update
+```
+
+`sls update` detects how sls was installed and runs the matching command —
+`brew upgrade sls` for Homebrew, the Linux package one-liner for deb/rpm,
+`go install …@latest` for source installs — asking for confirmation first.
+Manually-downloaded binaries are pointed at the releases page instead.
+
+```bash
+sls update --check   # report whether an update is available, without installing
+sls update --yes     # upgrade without the confirmation prompt
+```
+
+The background check is anonymous (a single request to the GitHub releases API),
+silent on failure, and skipped on dev builds and in non-interactive sessions.
+Disable it entirely with `export SLS_NO_UPDATE_CHECK=1`.
+
 ## Quick Start
 
 ```bash
@@ -194,6 +217,7 @@ sls completion [bash|zsh|fish|powershell]
 | `~/.config/sls/ssh_config` | Generated container SSH entries |
 | `~/.config/sls/telemetry` | Telemetry consent (`enabled`/`disabled`) |
 | `~/.config/sls/anon_id` | Random per-install anonymous id (see Telemetry) |
+| `~/.config/sls/update.json` | Cached latest-version check (see Updating) |
 
 ## Security
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jinmugo/sls/internal/hostinfo"
 	"github.com/jinmugo/sls/internal/onboarding"
 	"github.com/jinmugo/sls/internal/pulse"
+	"github.com/jinmugo/sls/internal/updater"
 	sshconfig "github.com/kevinburke/ssh_config"
 	"github.com/spf13/cobra"
 )
@@ -102,6 +103,15 @@ func runInteractive(extraSSHArgs []string) error {
 	var restoreAlias string
 	hasScanned := len(cache.Hosts) > 0
 
+	// Update check: build a banner from the last cached result, then refresh the
+	// cache in the background for next time. No-op when disabled, on dev builds,
+	// or when not running interactively.
+	var updateBanner string
+	if notice := updater.Cached(version); notice != nil {
+		updateBanner = fmt.Sprintf("⬆ sls %s available · run 'sls update'", notice.Latest)
+	}
+	updater.RefreshAsync(version)
+
 	// Main loop
 	for {
 		if needReloadHosts {
@@ -137,6 +147,7 @@ func runInteractive(extraSSHArgs []string) error {
 			HasScanned:     hasScanned,
 			InfoFetcher:    infoFetcher,
 			InfoCache:      infoCache,
+			UpdateBanner:   updateBanner,
 		}
 		if cacheWarning != "" {
 			opts.StatusMsg = cacheWarning
@@ -345,6 +356,9 @@ func Execute() {
 	pulse.Init(version)
 	defer pulse.Shutdown()
 
+	// Inject the running version so `sls update` can compare against the latest.
+	cli.Version = version
+
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
@@ -359,6 +373,7 @@ func init() {
 	rootCmd.AddCommand(cli.DiscoverCmd)
 	rootCmd.AddCommand(cli.ConnectCmd)
 	rootCmd.AddCommand(cli.GenCmd)
+	rootCmd.AddCommand(cli.UpdateCmd)
 
 	rootCmd.Flags().StringVarP(&filterTag, "tag", "t", "", "Filter hosts by tag")
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/jinmugo/sls/internal/updater"
+	"github.com/spf13/cobra"
+)
+
+// Version is the running sls version, injected by the cmd package before the
+// command tree executes. Used by `sls update` to compare against the latest
+// release.
+var Version = "dev"
+
+var (
+	updateCheckOnly bool
+	updateYes       bool
+)
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update sls to the latest version",
+	Long: `Update sls to the latest released version.
+
+sls detects how it was installed (Homebrew, the Linux package repo, or
+go install) and runs the matching upgrade command, asking for confirmation
+first. Manually-downloaded binaries are pointed at the releases page instead.
+
+Use --check to only report whether an update is available.`,
+	Args: cobra.NoArgs,
+	RunE: runUpdate,
+}
+
+// UpdateCmd is the exported handle registered on the root command.
+var UpdateCmd = updateCmd
+
+func init() {
+	updateCmd.Flags().BoolVar(&updateCheckOnly, "check", false, "Only check for an update; don't install")
+	updateCmd.Flags().BoolVarP(&updateYes, "yes", "y", false, "Skip the confirmation prompt")
+}
+
+func runUpdate(cmd *cobra.Command, args []string) error {
+	current := Version
+
+	if updateCheckOnly {
+		latest, ok := updater.LatestVersion(current)
+		fmt.Println(formatCheck(current, latest, ok))
+		return nil
+	}
+
+	// Avoid an unnecessary package-manager call when already current.
+	if latest, ok := updater.LatestVersion(current); ok && !updater.Outdated(current, latest) {
+		fmt.Printf("sls %s is already the latest version.\n", current)
+		return nil
+	}
+
+	method := updater.DetectMethod()
+	argv, needsSudo, ok := updater.UpgradeCommand(method)
+	if !ok {
+		fmt.Println(manualInstructions(method))
+		return nil
+	}
+
+	fmt.Printf("Detected install method: %s\n", method)
+	fmt.Printf("Will run: %s\n", strings.Join(argv, " "))
+	if needsSudo {
+		fmt.Println("This command needs sudo and may prompt for your password.")
+	}
+
+	if !updateYes && !confirm("Continue?") {
+		fmt.Println("Aborted.")
+		return nil
+	}
+
+	if err := runCommand(argv); err != nil {
+		return fmt.Errorf("update failed: %w", err)
+	}
+	fmt.Println("✓ Update complete. Run 'sls version' to confirm.")
+	return nil
+}
+
+// formatCheck renders the result of `sls update --check`.
+func formatCheck(current, latest string, ok bool) string {
+	if !ok {
+		return "Could not determine the latest version (network error?)."
+	}
+	if updater.Outdated(current, latest) {
+		return fmt.Sprintf("Update available: sls %s → %s. Run 'sls update' to upgrade.", current, latest)
+	}
+	return fmt.Sprintf("sls %s is up to date.", current)
+}
+
+// manualInstructions returns guidance for install methods with no safe automatic
+// upgrade command.
+func manualInstructions(m updater.Method) string {
+	var b strings.Builder
+	if m == updater.MethodUnknown {
+		b.WriteString("Could not detect how sls was installed.\n")
+	} else {
+		b.WriteString("sls was installed as a standalone binary.\n")
+	}
+	b.WriteString("Download the latest release for your platform from:\n  ")
+	b.WriteString(updater.ReleasesURL)
+	return b.String()
+}
+
+// confirm prompts the user for a yes/no answer, defaulting to yes on empty input.
+func confirm(prompt string) bool {
+	fmt.Printf("%s [Y/n] ", prompt)
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer == "" || answer == "y" || answer == "yes"
+}
+
+// runCommand executes argv, wiring through the current terminal so package
+// managers can prompt (e.g. for a sudo password) and stream their output.
+func runCommand(argv []string) error {
+	c := exec.Command(argv[0], argv[1:]...)
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jinmugo/sls/internal/updater"
+)
+
+func TestFormatCheck(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		latest  string
+		ok      bool
+		want    string // substring that must appear
+	}{
+		{"network failure", "1.1.1", "", false, "could not determine"},
+		{"update available", "1.1.1", "v1.1.2", true, "1.1.1 → v1.1.2"},
+		{"up to date", "1.1.2", "v1.1.2", true, "up to date"},
+		{"current newer", "1.2.0", "v1.1.2", true, "up to date"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatCheck(tt.current, tt.latest, tt.ok)
+			if !strings.Contains(strings.ToLower(got), strings.ToLower(tt.want)) {
+				t.Errorf("formatCheck(%q, %q, %v) = %q, want substring %q",
+					tt.current, tt.latest, tt.ok, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestManualInstructions(t *testing.T) {
+	for _, m := range []updater.Method{updater.MethodBinary, updater.MethodUnknown} {
+		got := manualInstructions(m)
+		if !strings.Contains(got, updater.ReleasesURL) {
+			t.Errorf("manualInstructions(%v) = %q, want it to include releases URL %q",
+				m, got, updater.ReleasesURL)
+		}
+	}
+}

--- a/internal/finder/banner_test.go
+++ b/internal/finder/banner_test.go
@@ -1,0 +1,33 @@
+package finder
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUpdateBannerRendered(t *testing.T) {
+	items := []Item{
+		{Label: "alpha", Alias: "alpha"},
+		{Label: "beta", Alias: "beta"},
+	}
+
+	banner := "⬆ sls v1.1.2 available · run 'sls update'"
+
+	t.Run("shown when set", func(t *testing.T) {
+		m := newModel(items, SelectOpts{UpdateBanner: banner})
+		m.width = 80
+		m.height = 24
+		if !strings.Contains(m.View(), "v1.1.2 available") {
+			t.Errorf("View() did not include the update banner:\n%s", m.View())
+		}
+	})
+
+	t.Run("absent when empty", func(t *testing.T) {
+		m := newModel(items, SelectOpts{})
+		m.width = 80
+		m.height = 24
+		if strings.Contains(m.View(), "available") {
+			t.Errorf("View() unexpectedly showed an update banner:\n%s", m.View())
+		}
+	})
+}

--- a/internal/finder/finder.go
+++ b/internal/finder/finder.go
@@ -38,13 +38,14 @@ type HostInfoFetcher interface {
 
 // SelectOpts configures the finder behavior.
 type SelectOpts struct {
-	StatusMsg      string           // temporary status message (e.g., "✓ Starred prod")
-	RestoreAlias   string           // alias to restore cursor to after rebuild
-	HostCount      int              // number of hosts (for header)
-	ContainerCount int              // number of containers (for header)
-	HasScanned     bool             // true if user has ever scanned (hides first-run hint)
-	InfoFetcher    HostInfoFetcher  // optional: provides host info for preview panel
-	InfoCache      *hostinfo.Cache  // optional: disk cache for persistence across sessions
+	StatusMsg      string          // temporary status message (e.g., "✓ Starred prod")
+	RestoreAlias   string          // alias to restore cursor to after rebuild
+	HostCount      int             // number of hosts (for header)
+	ContainerCount int             // number of containers (for header)
+	HasScanned     bool            // true if user has ever scanned (hides first-run hint)
+	InfoFetcher    HostInfoFetcher // optional: provides host info for preview panel
+	InfoCache      *hostinfo.Cache // optional: disk cache for persistence across sessions
+	UpdateBanner   string          // optional: persistent "update available" line
 }
 
 // Select launches the interactive finder TUI and returns the selected item's alias.
@@ -96,20 +97,21 @@ type model struct {
 	hostCount      int
 	containerCount int
 	hasScanned     bool
+	updateBanner   string // persistent "update available" line (empty when none)
 
 	// Preview panel
-	previewOpen   bool
-	infoFetcher   HostInfoFetcher
-	infoCache     *hostinfo.Cache
-	infoDirty     bool                       // true if cache was updated (needs flush)
-	infoMem       map[string]*hostinfo.HostInfo // in-memory cache for current session
-	loadingHost   string
-	fetchGen      uint64
-	cancelFetch   context.CancelFunc
-	listWidth     int
-	previewWidth  int
-	fetchDebounce *time.Timer
-	saveDebounce  *time.Timer
+	previewOpen    bool
+	infoFetcher    HostInfoFetcher
+	infoCache      *hostinfo.Cache
+	infoDirty      bool                          // true if cache was updated (needs flush)
+	infoMem        map[string]*hostinfo.HostInfo // in-memory cache for current session
+	loadingHost    string
+	fetchGen       uint64
+	cancelFetch    context.CancelFunc
+	listWidth      int
+	previewWidth   int
+	fetchDebounce  *time.Timer
+	saveDebounce   *time.Timer
 	prevCursorHost string // track cursor host to detect changes
 }
 
@@ -145,6 +147,7 @@ func newModel(items []Item, opts SelectOpts) model {
 		hasScanned:     opts.HasScanned,
 		infoFetcher:    opts.InfoFetcher,
 		infoCache:      opts.InfoCache,
+		updateBanner:   opts.UpdateBanner,
 		infoMem:        make(map[string]*hostinfo.HostInfo),
 	}
 
@@ -458,6 +461,11 @@ func (m model) View() string {
 	}
 	header += "\n" + StyleDim.Render(countStr)
 
+	// Persistent update-available banner
+	if m.updateBanner != "" {
+		header += "\n" + StyleDim.Render(m.updateBanner)
+	}
+
 	// Status flash
 	if m.statusMsg != "" {
 		header += "\n" + m.statusMsg
@@ -465,6 +473,9 @@ func (m model) View() string {
 
 	// Calculate available height
 	headerLines := 2
+	if m.updateBanner != "" {
+		headerLines++
+	}
 	if m.statusMsg != "" {
 		headerLines++
 	}
@@ -673,9 +684,9 @@ func (m model) buildHintBar() string {
 
 	// Full hints
 	if isContainer {
-		return "\n" + StyleDim.Render("  ^j/k up/down · enter connect · ^r rename · ^f star · ^d delete" + previewHint + " · esc quit")
+		return "\n" + StyleDim.Render("  ^j/k up/down · enter connect · ^r rename · ^f star · ^d delete"+previewHint+" · esc quit")
 	}
-	return "\n" + StyleDim.Render("  ^j/k up/down · enter connect · ^r rename · ^s scan · ^f star · ^d delete" + previewHint + " · esc quit")
+	return "\n" + StyleDim.Render("  ^j/k up/down · enter connect · ^r rename · ^s scan · ^f star · ^d delete"+previewHint+" · esc quit")
 }
 
 // truncatePlain truncates a plain-text string to maxWidth runes.

--- a/internal/updater/check.go
+++ b/internal/updater/check.go
@@ -1,0 +1,203 @@
+// Package updater provides a lightweight, non-blocking update checker for sls.
+//
+// On launch, the dashboard reads a local cache (~/.config/sls/update.json) to
+// decide whether to show an "update available" banner, while a background
+// goroutine refreshes that cache from the GitHub Releases API for the next run.
+// This mirrors the internal/pulse design: async, cached, and silent on failure.
+//
+// The check is on by default and can be disabled with SLS_NO_UPDATE_CHECK=1. It
+// is skipped for dev builds and non-interactive sessions.
+package updater
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jinmugo/sls/internal/util"
+)
+
+const (
+	cacheFile      = "update.json"
+	checkTTL       = 24 * time.Hour
+	requestTimeout = 5 * time.Second
+	repoSlug       = "jinmugo/sls"
+)
+
+// githubAPIBase is overridable in tests to point at an httptest server.
+var githubAPIBase = "https://api.github.com"
+
+var httpClient = &http.Client{Timeout: requestTimeout}
+
+// Notice is the information the dashboard banner needs about an available update.
+type Notice struct {
+	Latest string // the latest released version tag, e.g. "v1.1.2"
+}
+
+// cacheData is the on-disk shape of the update-check cache.
+type cacheData struct {
+	LastChecked   time.Time `json:"last_checked"`
+	LatestVersion string    `json:"latest_version"`
+}
+
+// Cached returns a Notice if the cached latest version is newer than current,
+// otherwise nil. A missing or corrupt cache yields nil (never an error) so the
+// banner path is always silent.
+func Cached(current string) *Notice {
+	c, err := readCache()
+	if err != nil || c == nil {
+		return nil
+	}
+	if Outdated(current, c.LatestVersion) {
+		return &Notice{Latest: c.LatestVersion}
+	}
+	return nil
+}
+
+// RefreshAsync refreshes the cache in the background when the check is enabled
+// and the cache is missing or older than the TTL. It never blocks the caller and
+// silently ignores all errors.
+func RefreshAsync(current string) {
+	if !needsRefresh(current, os.Getenv, isInteractive(), time.Now()) {
+		return
+	}
+	go func() { _ = refresh(current) }()
+}
+
+// LatestVersion fetches the latest released version, writing it to the cache.
+// On network failure it falls back to the cached value. The bool reports whether
+// any version could be determined. Used by `sls update --check`.
+func LatestVersion(current string) (string, bool) {
+	if tag, err := fetchLatest(current); err == nil {
+		_ = writeCache(&cacheData{LastChecked: time.Now().UTC(), LatestVersion: tag})
+		return tag, true
+	}
+	if c, err := readCache(); err == nil && c != nil && c.LatestVersion != "" {
+		return c.LatestVersion, true
+	}
+	return "", false
+}
+
+// Outdated reports whether latest is a newer version than current.
+func Outdated(current, latest string) bool {
+	return compareVersions(latest, current) > 0
+}
+
+// checkEnabled reports whether the update check should run at all.
+func checkEnabled(current string, env func(string) string, interactive bool) bool {
+	if v := env("SLS_NO_UPDATE_CHECK"); v == "1" || v == "true" {
+		return false
+	}
+	if current == "" || current == "dev" {
+		return false
+	}
+	return interactive
+}
+
+// needsRefresh reports whether a background refresh is warranted: the check must
+// be enabled, and the cache must be missing, unreadable, or older than the TTL.
+func needsRefresh(current string, env func(string) string, interactive bool, now time.Time) bool {
+	if !checkEnabled(current, env, interactive) {
+		return false
+	}
+	c, err := readCache()
+	if err != nil || c == nil {
+		return true
+	}
+	return now.Sub(c.LastChecked) >= checkTTL
+}
+
+// refresh fetches the latest version and writes it to the cache.
+func refresh(current string) error {
+	tag, err := fetchLatest(current)
+	if err != nil {
+		return err
+	}
+	return writeCache(&cacheData{LastChecked: time.Now().UTC(), LatestVersion: tag})
+}
+
+// fetchLatest queries the GitHub Releases API for the latest published tag.
+func fetchLatest(current string) (string, error) {
+	url := githubAPIBase + "/repos/" + repoSlug + "/releases/latest"
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "sls/"+current)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github api: unexpected status %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+	if payload.TagName == "" {
+		return "", errors.New("github api: empty tag_name")
+	}
+	return payload.TagName, nil
+}
+
+// cachePath returns the path to the update-check cache file.
+func cachePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "sls", cacheFile), nil
+}
+
+// readCache reads and parses the cache file. A missing file returns an error
+// (the standard not-exist error from os.ReadFile), so callers treat any error as
+// "no usable cache".
+func readCache() (*cacheData, error) {
+	p, err := cachePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+	var c cacheData
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// writeCache atomically writes the cache file.
+func writeCache(c *cacheData) error {
+	p, err := cachePath()
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	return util.AtomicWriteFile(p, data, 0o644)
+}
+
+// isInteractive reports whether stdin is connected to a terminal.
+func isInteractive() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}

--- a/internal/updater/check.go
+++ b/internal/updater/check.go
@@ -45,9 +45,14 @@ type cacheData struct {
 }
 
 // Cached returns a Notice if the cached latest version is newer than current,
-// otherwise nil. A missing or corrupt cache yields nil (never an error) so the
-// banner path is always silent.
+// otherwise nil. It honors the static opt-outs (SLS_NO_UPDATE_CHECK and dev/empty
+// builds) so a source build never nags, even when the shared cache holds a newer
+// release written by an installed sls on the same machine. A missing or corrupt
+// cache yields nil (never an error) so the banner path is always silent.
 func Cached(current string) *Notice {
+	if optedOut(current, os.Getenv) {
+		return nil
+	}
 	c, err := readCache()
 	if err != nil || c == nil {
 		return nil
@@ -87,15 +92,21 @@ func Outdated(current, latest string) bool {
 	return compareVersions(latest, current) > 0
 }
 
-// checkEnabled reports whether the update check should run at all.
-func checkEnabled(current string, env func(string) string, interactive bool) bool {
+// optedOut reports the static opt-outs that disable the update feature entirely,
+// independent of interactivity: the SLS_NO_UPDATE_CHECK env var and dev/source
+// builds (version "dev" or empty). Both the banner and the background refresh
+// respect these.
+func optedOut(current string, env func(string) string) bool {
 	if v := env("SLS_NO_UPDATE_CHECK"); v == "1" || v == "true" {
-		return false
+		return true
 	}
-	if current == "" || current == "dev" {
-		return false
-	}
-	return interactive
+	return current == "" || current == "dev"
+}
+
+// checkEnabled reports whether the background update check should run at all: not
+// opted out, and running interactively.
+func checkEnabled(current string, env func(string) string, interactive bool) bool {
+	return !optedOut(current, env) && interactive
 }
 
 // needsRefresh reports whether a background refresh is warranted: the check must

--- a/internal/updater/check_test.go
+++ b/internal/updater/check_test.go
@@ -49,6 +49,7 @@ func TestCached(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("HOME", t.TempDir())
+			t.Setenv("SLS_NO_UPDATE_CHECK", "") // isolate from the developer's shell
 			switch {
 			case tt.corrupt:
 				p, _ := cachePath()
@@ -69,6 +70,48 @@ func TestCached(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCachedRespectsGuards verifies that the banner path honors the same opt-outs
+// as the background refresh: a dev build and SLS_NO_UPDATE_CHECK must show no
+// banner even when a newer version sits in the cache. A regression here is what
+// made a locally-built `./sls` (version "dev") nag about an update.
+func TestCachedRespectsGuards(t *testing.T) {
+	t.Run("dev build shows no banner despite a newer cache", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("SLS_NO_UPDATE_CHECK", "")
+		writeTestCache(t, cacheData{LatestVersion: "v1.3.0"})
+		if got := Cached("dev"); got != nil {
+			t.Errorf("Cached(%q) = %+v, want nil (dev builds must not nag)", "dev", got)
+		}
+	})
+
+	t.Run("empty version shows no banner", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("SLS_NO_UPDATE_CHECK", "")
+		writeTestCache(t, cacheData{LatestVersion: "v1.3.0"})
+		if got := Cached(""); got != nil {
+			t.Errorf("Cached(%q) = %+v, want nil", "", got)
+		}
+	})
+
+	t.Run("opt-out env shows no banner", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("SLS_NO_UPDATE_CHECK", "1")
+		writeTestCache(t, cacheData{LatestVersion: "v1.3.0"})
+		if got := Cached("1.1.1"); got != nil {
+			t.Errorf("Cached with SLS_NO_UPDATE_CHECK=1 = %+v, want nil", got)
+		}
+	})
+
+	t.Run("normal build still shows the banner", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("SLS_NO_UPDATE_CHECK", "")
+		writeTestCache(t, cacheData{LatestVersion: "v1.3.0"})
+		if got := Cached("1.1.1"); got == nil {
+			t.Error("Cached(\"1.1.1\") = nil, want a notice")
+		}
+	})
 }
 
 func TestFetchLatest(t *testing.T) {

--- a/internal/updater/check_test.go
+++ b/internal/updater/check_test.go
@@ -1,0 +1,239 @@
+package updater
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeTestCache writes a cache file under a temp HOME and returns nothing;
+// callers set HOME via t.Setenv first.
+func writeTestCache(t *testing.T, c cacheData) {
+	t.Helper()
+	p, err := cachePath()
+	if err != nil {
+		t.Fatalf("cachePath: %v", err)
+	}
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestCached(t *testing.T) {
+	tests := []struct {
+		name    string
+		cache   *cacheData // nil = no cache file
+		corrupt bool
+		current string
+		want    *Notice
+	}{
+		{"update available", &cacheData{LatestVersion: "1.1.2"}, false, "1.1.1", &Notice{Latest: "1.1.2"}},
+		{"up to date", &cacheData{LatestVersion: "1.1.2"}, false, "1.1.2", nil},
+		{"current newer than cache", &cacheData{LatestVersion: "1.1.2"}, false, "1.2.0", nil},
+		{"v-prefixed tag in cache", &cacheData{LatestVersion: "v1.1.2"}, false, "1.1.1", &Notice{Latest: "v1.1.2"}},
+		{"no cache file", nil, false, "1.1.1", nil},
+		{"corrupt cache", nil, true, "1.1.1", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			switch {
+			case tt.corrupt:
+				p, _ := cachePath()
+				_ = os.MkdirAll(filepath.Dir(p), 0o755)
+				_ = os.WriteFile(p, []byte("{not json"), 0o644)
+			case tt.cache != nil:
+				writeTestCache(t, *tt.cache)
+			}
+
+			got := Cached(tt.current)
+			switch {
+			case tt.want == nil && got != nil:
+				t.Fatalf("Cached = %+v, want nil", got)
+			case tt.want != nil && got == nil:
+				t.Fatalf("Cached = nil, want %+v", tt.want)
+			case tt.want != nil && got.Latest != tt.want.Latest:
+				t.Fatalf("Cached.Latest = %q, want %q", got.Latest, tt.want.Latest)
+			}
+		})
+	}
+}
+
+func TestFetchLatest(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "happy path",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("User-Agent") == "" {
+					t.Errorf("missing User-Agent header")
+				}
+				_, _ = w.Write([]byte(`{"tag_name":"v1.1.2"}`))
+			},
+			want: "v1.1.2",
+		},
+		{
+			name: "rate limited",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed json",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{not json`))
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty tag",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{"tag_name":""}`))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(tt.handler)
+			defer srv.Close()
+			orig := githubAPIBase
+			githubAPIBase = srv.URL
+			defer func() { githubAPIBase = orig }()
+
+			got, err := fetchLatest("1.1.1")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("fetchLatest = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRefreshWritesCache(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.0"}`))
+	}))
+	defer srv.Close()
+	orig := githubAPIBase
+	githubAPIBase = srv.URL
+	defer func() { githubAPIBase = orig }()
+
+	if err := refresh("1.1.1"); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	c, err := readCache()
+	if err != nil || c == nil {
+		t.Fatalf("readCache after refresh: c=%v err=%v", c, err)
+	}
+	if c.LatestVersion != "v1.2.0" {
+		t.Errorf("cached latest = %q, want v1.2.0", c.LatestVersion)
+	}
+	if time.Since(c.LastChecked) > time.Minute {
+		t.Errorf("LastChecked not recent: %v", c.LastChecked)
+	}
+
+	// And the banner should now reflect the freshly-written cache.
+	if n := Cached("1.1.1"); n == nil || n.Latest != "v1.2.0" {
+		t.Errorf("Cached after refresh = %+v, want Latest=v1.2.0", n)
+	}
+}
+
+func TestCheckEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		current     string
+		env         map[string]string
+		interactive bool
+		want        bool
+	}{
+		{"normal interactive", "1.1.1", nil, true, true},
+		{"dev build", "dev", nil, true, false},
+		{"empty version", "", nil, true, false},
+		{"opt out with 1", "1.1.1", map[string]string{"SLS_NO_UPDATE_CHECK": "1"}, true, false},
+		{"opt out with true", "1.1.1", map[string]string{"SLS_NO_UPDATE_CHECK": "true"}, true, false},
+		{"not interactive", "1.1.1", nil, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkEnabled(tt.current, envFunc(tt.env), tt.interactive)
+			if got != tt.want {
+				t.Errorf("checkEnabled = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNeedsRefresh(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+
+	t.Run("disabled never refreshes", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		if needsRefresh("dev", envFunc(nil), true, now) {
+			t.Error("dev build should not refresh")
+		}
+	})
+
+	t.Run("no cache refreshes", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		if !needsRefresh("1.1.1", envFunc(nil), true, now) {
+			t.Error("missing cache should trigger refresh")
+		}
+	})
+
+	t.Run("fresh cache does not refresh", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		writeTestCache(t, cacheData{LastChecked: now.Add(-1 * time.Hour), LatestVersion: "1.1.1"})
+		if needsRefresh("1.1.1", envFunc(nil), true, now) {
+			t.Error("cache younger than TTL should not refresh")
+		}
+	})
+
+	t.Run("stale cache refreshes", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		writeTestCache(t, cacheData{LastChecked: now.Add(-48 * time.Hour), LatestVersion: "1.1.1"})
+		if !needsRefresh("1.1.1", envFunc(nil), true, now) {
+			t.Error("cache older than TTL should refresh")
+		}
+	})
+}
+
+func TestOutdated(t *testing.T) {
+	if !Outdated("1.1.1", "1.1.2") {
+		t.Error("1.1.1 should be outdated vs 1.1.2")
+	}
+	if Outdated("1.1.2", "1.1.2") {
+		t.Error("equal versions are not outdated")
+	}
+	if Outdated("1.2.0", "1.1.2") {
+		t.Error("newer current is not outdated")
+	}
+}

--- a/internal/updater/detect.go
+++ b/internal/updater/detect.go
@@ -1,0 +1,110 @@
+package updater
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+)
+
+// Method identifies how the running sls binary was installed, which determines
+// the correct upgrade command.
+type Method int
+
+const (
+	MethodUnknown Method = iota
+	MethodBrew
+	MethodPackage // deb/rpm via the package repo (curl install.sh)
+	MethodGoInstall
+	MethodBinary // manually downloaded binary
+)
+
+// String returns a human-readable label for the install method.
+func (m Method) String() string {
+	switch m {
+	case MethodBrew:
+		return "Homebrew"
+	case MethodPackage:
+		return "package manager"
+	case MethodGoInstall:
+		return "go install"
+	case MethodBinary:
+		return "binary download"
+	default:
+		return "unknown"
+	}
+}
+
+// brewExclusivePrefixes are Homebrew roots used by no other installer, so any
+// binary beneath them is a brew install even before symlink resolution. The
+// Intel-mac root (/usr/local) is intentionally excluded: /usr/local/bin is also
+// used by manual installs, so it is only treated as brew via its /Cellar/ path.
+var brewExclusivePrefixes = []string{
+	"/opt/homebrew",              // Apple Silicon
+	"/home/linuxbrew/.linuxbrew", // Linuxbrew
+}
+
+// DetectMethod determines how the running sls binary was installed by inspecting
+// the resolved executable path. Returns MethodUnknown only if the executable
+// path cannot be determined.
+func DetectMethod() Method {
+	exe, err := os.Executable()
+	if err != nil {
+		return MethodUnknown
+	}
+	// Resolve symlinks so Homebrew bin shims (/opt/homebrew/bin/sls -> ../Cellar/...)
+	// are detected by their real Cellar path.
+	if resolved, rerr := filepath.EvalSymlinks(exe); rerr == nil {
+		exe = resolved
+	}
+	return detectMethod(exe, runtime.GOOS, os.Getenv)
+}
+
+// detectMethod is the testable core of DetectMethod. exePath is the resolved
+// path to the binary; goos is the target OS; env looks up environment variables.
+func detectMethod(exePath, goos string, env func(string) string) Method {
+	p := filepath.ToSlash(exePath)
+
+	// Homebrew: a /Cellar/ component (covers /usr/local/Cellar on Intel macs and
+	// resolved bin shims), or a brew-exclusive prefix (covers unresolved shims).
+	if strings.Contains(p, "/Cellar/") {
+		return MethodBrew
+	}
+	for _, prefix := range brewExclusivePrefixes {
+		if strings.HasPrefix(p, prefix+"/") {
+			return MethodBrew
+		}
+	}
+
+	// go install: the binary lives in a Go bin directory.
+	if slices.Contains(goBinDirs(env), path.Dir(p)) {
+		return MethodGoInstall
+	}
+
+	// Package repo (deb/rpm) installs to /usr/bin on Linux (nfpm bindir).
+	if goos == "linux" && p == "/usr/bin/sls" {
+		return MethodPackage
+	}
+
+	return MethodBinary
+}
+
+// goBinDirs returns the candidate Go binary install directories, honoring GOBIN,
+// GOPATH, and the default $HOME/go/bin.
+func goBinDirs(env func(string) string) []string {
+	var dirs []string
+	if gobin := env("GOBIN"); gobin != "" {
+		dirs = append(dirs, filepath.ToSlash(gobin))
+	}
+	if gopath := env("GOPATH"); gopath != "" {
+		for _, gp := range filepath.SplitList(gopath) {
+			dirs = append(dirs, filepath.ToSlash(filepath.Join(gp, "bin")))
+		}
+	}
+	if home := env("HOME"); home != "" {
+		dirs = append(dirs, filepath.ToSlash(filepath.Join(home, "go", "bin")))
+	}
+	return dirs
+}

--- a/internal/updater/detect_test.go
+++ b/internal/updater/detect_test.go
@@ -1,0 +1,114 @@
+package updater
+
+import "testing"
+
+func envFunc(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func TestDetectMethod(t *testing.T) {
+	tests := []struct {
+		name    string
+		exePath string
+		goos    string
+		env     map[string]string
+		want    Method
+	}{
+		{
+			name:    "homebrew apple silicon cellar",
+			exePath: "/opt/homebrew/Cellar/sls/1.1.1/bin/sls",
+			goos:    "darwin",
+			want:    MethodBrew,
+		},
+		{
+			name:    "homebrew bin symlink prefix unresolved",
+			exePath: "/opt/homebrew/bin/sls",
+			goos:    "darwin",
+			want:    MethodBrew,
+		},
+		{
+			name:    "homebrew intel mac cellar",
+			exePath: "/usr/local/Cellar/sls/1.1.1/bin/sls",
+			goos:    "darwin",
+			want:    MethodBrew,
+		},
+		{
+			name:    "linuxbrew cellar",
+			exePath: "/home/linuxbrew/.linuxbrew/Cellar/sls/1.1.1/bin/sls",
+			goos:    "linux",
+			want:    MethodBrew,
+		},
+		{
+			name:    "go install via GOBIN",
+			exePath: "/custom/gobin/sls",
+			goos:    "darwin",
+			env:     map[string]string{"GOBIN": "/custom/gobin"},
+			want:    MethodGoInstall,
+		},
+		{
+			name:    "go install via GOPATH",
+			exePath: "/home/u/go/bin/sls",
+			goos:    "linux",
+			env:     map[string]string{"GOPATH": "/home/u/go"},
+			want:    MethodGoInstall,
+		},
+		{
+			name:    "go install via HOME default",
+			exePath: "/home/u/go/bin/sls",
+			goos:    "linux",
+			env:     map[string]string{"HOME": "/home/u"},
+			want:    MethodGoInstall,
+		},
+		{
+			name:    "linux package manager in usr bin",
+			exePath: "/usr/bin/sls",
+			goos:    "linux",
+			want:    MethodPackage,
+		},
+		{
+			name:    "linux manual binary in usr local bin",
+			exePath: "/usr/local/bin/sls",
+			goos:    "linux",
+			want:    MethodBinary,
+		},
+		{
+			name:    "darwin usr bin is not package",
+			exePath: "/usr/bin/sls",
+			goos:    "darwin",
+			want:    MethodBinary,
+		},
+		{
+			name:    "arbitrary path is binary",
+			exePath: "/home/u/bin/sls",
+			goos:    "linux",
+			want:    MethodBinary,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectMethod(tt.exePath, tt.goos, envFunc(tt.env))
+			if got != tt.want {
+				t.Errorf("detectMethod(%q, %q) = %v, want %v", tt.exePath, tt.goos, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMethodString(t *testing.T) {
+	tests := []struct {
+		m    Method
+		want string
+	}{
+		{MethodBrew, "Homebrew"},
+		{MethodPackage, "package manager"},
+		{MethodGoInstall, "go install"},
+		{MethodBinary, "binary download"},
+		{MethodUnknown, "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.m.String(); got != tt.want {
+			t.Errorf("Method(%d).String() = %q, want %q", tt.m, got, tt.want)
+		}
+	}
+}

--- a/internal/updater/upgrade.go
+++ b/internal/updater/upgrade.go
@@ -1,0 +1,34 @@
+package updater
+
+const (
+	// packageUpgradeOneLiner re-runs the documented install script, which installs
+	// the latest version through the system package manager (apt/yum). The inner
+	// "sudo" handles privilege elevation.
+	packageUpgradeOneLiner = "curl -fsSL https://package.jinmu.me/install.sh | sudo sh -s sls"
+
+	// goModulePath is the module path used by `go install`.
+	goModulePath = "github.com/jinmugo/sls"
+
+	// ReleasesURL is the GitHub releases page, shown for manual install methods.
+	ReleasesURL = "https://github.com/jinmugo/sls/releases"
+)
+
+// UpgradeCommand maps an install method to the command that upgrades sls.
+//
+// The returned argv is executed verbatim by the caller; needsSudo is purely
+// informational (it drives the confirmation message) and the caller never
+// prepends "sudo" — the package one-liner already contains its own. ok is false
+// when there is no safe automatic command (manual binary / unknown installs), in
+// which case the caller should print manual instructions instead.
+func UpgradeCommand(m Method) (argv []string, needsSudo bool, ok bool) {
+	switch m {
+	case MethodBrew:
+		return []string{"brew", "upgrade", "sls"}, false, true
+	case MethodPackage:
+		return []string{"sh", "-c", packageUpgradeOneLiner}, true, true
+	case MethodGoInstall:
+		return []string{"go", "install", goModulePath + "@latest"}, false, true
+	default:
+		return nil, false, false
+	}
+}

--- a/internal/updater/upgrade_test.go
+++ b/internal/updater/upgrade_test.go
@@ -1,0 +1,66 @@
+package updater
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUpgradeCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   Method
+		wantArgv []string
+		wantSudo bool
+		wantOK   bool
+	}{
+		{
+			name:     "brew",
+			method:   MethodBrew,
+			wantArgv: []string{"brew", "upgrade", "sls"},
+			wantSudo: false,
+			wantOK:   true,
+		},
+		{
+			name:     "package re-runs install one-liner with sudo",
+			method:   MethodPackage,
+			wantArgv: []string{"sh", "-c", "curl -fsSL https://package.jinmu.me/install.sh | sudo sh -s sls"},
+			wantSudo: true,
+			wantOK:   true,
+		},
+		{
+			name:     "go install",
+			method:   MethodGoInstall,
+			wantArgv: []string{"go", "install", "github.com/jinmugo/sls@latest"},
+			wantSudo: false,
+			wantOK:   true,
+		},
+		{
+			name:   "binary has no automatic command",
+			method: MethodBinary,
+			wantOK: false,
+		},
+		{
+			name:   "unknown has no automatic command",
+			method: MethodUnknown,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argv, sudo, ok := UpgradeCommand(tt.method)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if !reflect.DeepEqual(argv, tt.wantArgv) {
+				t.Errorf("argv = %v, want %v", argv, tt.wantArgv)
+			}
+			if sudo != tt.wantSudo {
+				t.Errorf("needsSudo = %v, want %v", sudo, tt.wantSudo)
+			}
+		})
+	}
+}

--- a/internal/updater/version.go
+++ b/internal/updater/version.go
@@ -1,0 +1,159 @@
+package updater
+
+import (
+	"strconv"
+	"strings"
+)
+
+// compareVersions compares two semantic version strings and returns -1 if a < b,
+// 0 if a == b, and 1 if a > b. A leading "v" is ignored. Missing components are
+// treated as zero (so "1.1" == "1.1.0"). A pre-release suffix (e.g. "-rc1") sorts
+// lower than the corresponding release; two pre-releases are compared lexically.
+//
+// It is intentionally dependency-free — sls uses simple vX.Y.Z tags and the
+// project values having zero external dependencies for core logic.
+func compareVersions(a, b string) int {
+	aCore, aPre := splitVersion(a)
+	bCore, bPre := splitVersion(b)
+
+	if c := compareCore(aCore, bCore); c != 0 {
+		return c
+	}
+
+	// Cores are equal — a release outranks a pre-release.
+	switch {
+	case aPre == "" && bPre == "":
+		return 0
+	case aPre == "":
+		return 1
+	case bPre == "":
+		return -1
+	}
+	return comparePrerelease(aPre, bPre)
+}
+
+// comparePrerelease compares two non-empty pre-release suffixes. Identifiers are
+// split on "." and compared in order; a suffix with fewer identifiers ranks lower
+// when it is a prefix of the other. Each identifier is compared with natural
+// ordering so that, in addition to strict semver dotted numerics ("alpha.2" <
+// "alpha.10"), the common un-dotted style also sorts intuitively ("rc9" < "rc10").
+func comparePrerelease(a, b string) int {
+	aIDs := strings.Split(a, ".")
+	bIDs := strings.Split(b, ".")
+	n := max(len(aIDs), len(bIDs))
+
+	for i := range n {
+		// A shorter pre-release (a prefix of the other) has lower precedence.
+		if i >= len(aIDs) {
+			return -1
+		}
+		if i >= len(bIDs) {
+			return 1
+		}
+		if c := compareIdentifier(aIDs[i], bIDs[i]); c != 0 {
+			return c
+		}
+	}
+	return 0
+}
+
+// compareIdentifier compares two pre-release identifiers using natural ordering:
+// maximal digit and non-digit runs are compared pairwise, digit runs numerically
+// and non-digit runs lexically. A digit run ranks lower than a non-digit run, and
+// the shorter identifier ranks lower when it is a prefix of the other.
+func compareIdentifier(a, b string) int {
+	ai, bi := 0, 0
+	for ai < len(a) && bi < len(b) {
+		aRun, aDigit, aNext := nextRun(a, ai)
+		bRun, bDigit, bNext := nextRun(b, bi)
+
+		switch {
+		case aDigit && bDigit:
+			if c := compareNumericRun(aRun, bRun); c != 0 {
+				return c
+			}
+		case aDigit != bDigit:
+			if aDigit { // numeric runs rank lower than alphabetic
+				return -1
+			}
+			return 1
+		default:
+			if c := strings.Compare(aRun, bRun); c != 0 {
+				return c
+			}
+		}
+		ai, bi = aNext, bNext
+	}
+	switch {
+	case ai < len(a):
+		return 1
+	case bi < len(b):
+		return -1
+	}
+	return 0
+}
+
+// nextRun returns the maximal run of same-class (digit / non-digit) characters
+// starting at i, whether that run is digits, and the index past it.
+func nextRun(s string, i int) (run string, isDigit bool, next int) {
+	isDigit = s[i] >= '0' && s[i] <= '9'
+	j := i
+	for j < len(s) && (s[j] >= '0' && s[j] <= '9') == isDigit {
+		j++
+	}
+	return s[i:j], isDigit, j
+}
+
+// compareNumericRun compares two digit runs by numeric value, tolerating leading
+// zeros and arbitrarily large numbers (length-then-lexical avoids overflow).
+func compareNumericRun(a, b string) int {
+	a = strings.TrimLeft(a, "0")
+	b = strings.TrimLeft(b, "0")
+	if len(a) != len(b) {
+		if len(a) < len(b) {
+			return -1
+		}
+		return 1
+	}
+	return strings.Compare(a, b)
+}
+
+// splitVersion strips a leading "v" and splits the numeric core from an optional
+// pre-release suffix introduced by "-".
+func splitVersion(v string) (core, pre string) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	core, pre, _ = strings.Cut(v, "-")
+	return core, pre
+}
+
+// compareCore compares two dotted numeric version cores component by component.
+func compareCore(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+
+	n := max(len(aParts), len(bParts))
+
+	for i := range n {
+		av := numAt(aParts, i)
+		bv := numAt(bParts, i)
+		if av < bv {
+			return -1
+		}
+		if av > bv {
+			return 1
+		}
+	}
+	return 0
+}
+
+// numAt returns the integer at index i, or 0 if out of range / unparseable.
+func numAt(parts []string, i int) int {
+	if i >= len(parts) {
+		return 0
+	}
+	n, err := strconv.Atoi(parts[i])
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/updater/version_test.go
+++ b/internal/updater/version_test.go
@@ -1,0 +1,42 @@
+package updater
+
+import "testing"
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{"equal", "1.1.1", "1.1.1", 0},
+		{"equal with v prefix on one side", "v1.1.1", "1.1.1", 0},
+		{"equal with v prefix on both", "v1.1.1", "v1.1.1", 0},
+		{"older patch", "1.1.0", "1.1.1", -1},
+		{"newer patch", "1.1.2", "1.1.1", 1},
+		{"minor beats patch", "1.2.0", "1.1.9", 1},
+		{"major beats minor", "2.0.0", "1.9.9", 1},
+		{"missing patch treated as zero", "1.1", "1.1.0", 0},
+		{"missing minor treated as zero", "1", "1.0.0", 0},
+		{"double digit patch", "1.1.10", "1.1.9", 1},
+		{"prerelease lower than release", "1.1.0-rc1", "1.1.0", -1},
+		{"release higher than prerelease", "1.1.0", "1.1.0-rc1", 1},
+		{"prerelease single digit ordering", "1.1.0-rc1", "1.1.0-rc2", -1},
+		{"prerelease multi digit ordering", "1.1.0-rc9", "1.1.0-rc10", -1},
+		{"prerelease multi digit reverse", "1.1.0-rc10", "1.1.0-rc2", 1},
+		{"prerelease equal", "1.1.0-rc3", "1.1.0-rc3", 0},
+		{"prerelease dotted numeric identifiers", "1.0.0-alpha.2", "1.0.0-alpha.10", -1},
+		{"prerelease numeric lower than alpha identifier", "1.0.0-1", "1.0.0-alpha", -1},
+		{"prerelease fewer identifiers lower", "1.0.0-alpha", "1.0.0-alpha.1", -1},
+		{"prerelease alpha lexical", "1.0.0-alpha", "1.0.0-beta", -1},
+		{"v prefixed newer", "v1.1.2", "v1.1.1", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareVersions(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("compareVersions(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When `sls` launches the dashboard it now checks (in the background, at most once a day) whether a newer release exists and shows a dim banner: `⬆ sls vX.Y.Z available · run 'sls update'`. A new `sls update` command detects how `sls` was installed and runs the matching upgrade with a confirmation prompt.

The checker mirrors the existing `internal/pulse` shape: async, cached, silent on failure, TTY-gated.

### What's new

**`internal/updater/` (new package)**
- `check.go` — cache at `~/.config/sls/update.json` (24h TTL), GitHub Releases API fetch, fire-and-forget background refresh, `Cached`/`LatestVersion`/`Outdated` helpers. Guards: `SLS_NO_UPDATE_CHECK=1`, dev builds, non-interactive sessions.
- `version.go` — dependency-free semver compare. Pre-release suffixes use natural ordering, so `rc9 < rc10` and `alpha.2 < alpha.10` sort correctly.
- `detect.go` — install-method detection (`DetectMethod`) from the resolved executable path → Homebrew / Linux package / `go install` / standalone binary.
- `upgrade.go` — `UpgradeCommand` maps each method to its upgrade argv.

**`internal/cli/update.go`** — `sls update` command:
- Default: detect → show the plan → confirm `[Y/n]` → run, inheriting stdio.
- `--check` — report status only, no action, always exits 0 (scriptable).
- `-y/--yes` — skip the confirmation prompt (sudo's own prompt still applies).
- Standalone binaries get manual instructions + the Releases URL instead of an auto-command.

**Wiring** — `cmd/root.go` builds the banner from the cache and fires the background refresh; `internal/finder` renders a persistent `UpdateBanner` header line.

Upgrade commands by method: Homebrew → `brew upgrade sls`; Linux package → the documented `curl … install.sh | sudo sh -s sls` one-liner; `go install` → `go install …@latest`.

## Test Coverage

Built test-first (TDD, RED→GREEN per unit). No new dependencies.
- `compareVersions` — equal/older/newer, missing components, `v`-prefix, single- and multi-digit pre-release ordering.
- `detectMethod(exePath, goos, env)` — brew (Cellar + prefixes), `go install` (GOBIN/GOPATH/HOME), linux `/usr/bin` package, binary fallbacks, per-OS.
- cache read/write/TTL (temp HOME; missing + corrupt), `fetchLatest` via `httptest` (200 / 403 / malformed / empty tag), `UpgradeCommand` mapping, CLI `formatCheck`/`manualInstructions`, finder banner render.

`go vet ./...`, `gofmt`, and `go test -race ./...` all clean.

## Pre-Landing Review

Ran a 4-dimension adversarial review (correctness, concurrency, integration, security), each finding independently verified. 13 raised → 3 confirmed:
- **Fixed (this PR):** `compareVersions` ranked multi-digit pre-releases lexically (`rc9 > rc10`). Replaced with natural-segment comparison + 7 new test cases.
- **Deferred (pre-existing, out of scope):** two `internal/finder` height-math quirks (first-run tip overflow; a wasted `hintLines` row) that predate this feature and are unrelated to the banner. Verifier confirmed they're bounded/cosmetic under alt-screen.

No command injection: `UpgradeCommand` returns fixed argv; the GitHub tag is only displayed/compared, never shelled. `needsSudo` is informational only — the caller never prepends `sudo`.

## Test plan

- [x] `go build` succeeds; pre-commit (vet + build) and pre-push (test) hooks pass
- [x] `go test -race ./...` — all packages pass
- [x] Smoke: `sls update --check` reports `Update available: sls 1.0.0 → v1.2.2` (real GitHub fetch); `sls update` on a standalone binary prints manual instructions without executing

🤖 Generated with [Claude Code](https://claude.com/claude-code)