### PR TITLE
chore: remove fzf dependency from install packages

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,6 @@ Describe what you expected to happen instead.
 
 - OS: [e.g. macOS Ventura, Ubuntu 22.04]
 - sls version: output of `sls --version`
-- fzf version: output of `fzf --version`
 
 ## Additional Context
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -72,8 +72,6 @@ brews:
       system "#{bin}/sls version"
     install: |
       bin.install "sls"
-    dependencies:
-      - name: fzf
 
 nfpms:
   - id: sls
@@ -86,8 +84,6 @@ nfpms:
     formats:
       - deb
       - rpm
-    dependencies:
-      - fzf
     bindir: /usr/bin
     contents:
       - src: ./LICENSE


### PR DESCRIPTION
## What

Removes `fzf` from the install dependency lists so it's no longer downloaded alongside `sls`.

- **Homebrew** (`brews.dependencies` in `.goreleaser.yaml`) — `brew install sls` no longer pulls fzf
- **deb/rpm** (`nfpms.dependencies`) — the `curl … package.jinmu.me/install.sh` Linux path no longer pulls fzf
- Bug-report template: dropped the now-irrelevant `fzf --version` field

## Why

`sls` renders its own Bubbletea TUI and never invokes `fzf` at runtime (verified: no `exec`/`Command`/`LookPath` of fzf anywhere in the Go code — the only remaining references are a help-string noting `sls preview` can be used *as* an fzf preview command, and a descriptive `// fzf-style` rendering comment). The fzf dependency was dead weight and contradicted the README's "Zero dependencies" claim.

## Notes

- No committed `install.sh` or tap formula in this repo — the `jinmugo/homebrew-tap` formula and the deb/rpm packages are regenerated by GoReleaser on the **next release**, so fzf drops out automatically then. Existing installs keep fzf until upgraded.
- No version bump in this PR: the project versions via git tags + GoReleaser (latest `v1.3.1`); the release tag is cut from `main` after merge.

## Verification

- `goreleaser check` — config valid
- `go build ./...`, `go vet ./...`, `go test ./...` — all pass (diff touches no Go code)